### PR TITLE
Configure GITHUB_TOKEN permissions for deployment

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -2,6 +2,12 @@ name: Greetings
 
 on: [pull_request_target, issues]
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
 jobs:
   greeting:
     runs-on: ubuntu-latest
@@ -14,3 +20,4 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         issue-message: "Message that will be displayed on users' first issue"
         pr-message: "Message that will be displayed on users' first pull request"
+  


### PR DESCRIPTION
Added permissions for GITHUB_TOKEN to enable GitHub Pages deployment.

This may not be testable since the greeting is only ever displayed to any one user once.
